### PR TITLE
Adds update-slack-status step

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,19 @@
 A collection of simple Workflow Builder extensions (aka Steps from Apps) to serve as examples and be useful in their own right. 
 
 ![under construction](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fmondrian.mashable.com%2Fuploads%25252Fcard%25252Fimage%25252F168421%25252Ftumblr_ks4m18IymX1qz4u07o1_250.gif%25252Ffull-fit-in__950x534.gif%3Fsignature%3DQmYdcxMZN9xRJEWdrQIXh3KiiUQ%3D%26source%3Dhttps%253A%252F%252Fblueprint-api-production.s3.amazonaws.com&f=1&nofb=1)
+
+
+## Configuration
+To run locally you'll need a `.env` file with these properties:
+
+```
+export SLACK_SIGNING_SECRET=
+export SLACK_CLIENT_ID=
+export SLACK_CLIENT_SECRET=
+export SLACK_VERIFICATION_TOKEN=
+export STATE_SECRET=
+export HOST=https://host
+export REDIS_URL=redis://127.0.0.1:6379
+```
+
+And then to run with nodemon: `npm run-script dev`

--- a/storage.js
+++ b/storage.js
@@ -1,46 +1,69 @@
 import { promisify } from "util";
-import redis from"redis";
+import redis from "redis";
 
 const makeInstalledTeamKey = (teamId) => `team-install-${teamId}`;
-const makeUserCredentialKey = (teamId, userId) => `user-credential-${teamId}:${userId}`;
+const makeUserCredentialKey = (teamId, userId) =>
+  `user-credential-${teamId}:${userId}`;
+const makeStepCredentialId = (workflowId, stepId) =>
+  `step-credential-${workflowId}:${stepId}`;
 
 export const initializeStorage = (redisURL) => {
   const redisClient = redis.createClient(process.env.REDIS_URL);
-  redisClient.on("error", error => console.error(error));
-  redisClient.on("connect", () => console.error("🙆‍♂️Redis connected"));
+  redisClient.on("error", (error) => console.error(error));
+  redisClient.on("connect", () => console.error("🙆‍♂️ Redis connected"));
   const redisGet = promisify(redisClient.get).bind(redisClient);
   const redisSet = promisify(redisClient.set).bind(redisClient);
-  
+
   return {
     // saves a Bolt installed team object
     saveInstalledTeam: async (installation) => {
-      const key = makeInstalledTeamKey(installation.team.id)
-      const value = JSON.stringify(installation)
-      return await redisSet(key, value)
+      const key = makeInstalledTeamKey(installation.team.id);
+      const value = JSON.stringify(installation);
+      return await redisSet(key, value);
     },
 
     // returns the whole Bolt installed team object
     getInstalledTeam: async (teamId) => {
-      const key = makeInstalledTeamKey(teamId)
-      const val = await redisGet(key)
+      const key = makeInstalledTeamKey(teamId);
+      const val = await redisGet(key);
       try {
-        return JSON.parse(val)
-      } catch(e) {
+        return JSON.parse(val);
+      } catch (e) {
         console.error(`Error parsing ${key} from Redis:`, e.message);
-        return null
+        return null;
       }
     },
 
     // stores a user token for an install by a particular user of a team
     setUserCredential: async (teamId, userId, token) => {
       const key = makeUserCredentialKey(teamId, userId);
-      return await redisSet(key, token)
+      return await redisSet(key, token);
     },
 
     // Get a user token for an install by a particular user of a team
     getUserCredential: async (teamId, userId) => {
       const key = makeUserCredentialKey(teamId, userId);
-      return await redisGet(key)
-    }
-  }
-}
+      return await redisGet(key);
+    },
+
+    setStepCredential: async (workflowId, stepId, teamId, userId) => {
+      const key = makeStepCredentialId(workflowId, stepId);
+      const stepCredential = { teamId, userId };
+
+      await redisSet(key, JSON.stringify(stepCredential));
+
+      return stepCredential;
+    },
+
+    getStepCredential: async (workflowId, stepId) => {
+      const key = makeStepCredentialId(workflowId, stepId);
+      const val = await redisGet(key);
+      try {
+        return JSON.parse(val);
+      } catch (e) {
+        console.error(`Error parsing ${key} from Redis:`, e.message);
+        return null;
+      }
+    },
+  };
+};

--- a/storage.js
+++ b/storage.js
@@ -1,0 +1,46 @@
+import { promisify } from "util";
+import redis from"redis";
+
+const makeInstalledTeamKey = (teamId) => `team-install-${teamId}`;
+const makeUserCredentialKey = (teamId, userId) => `user-credential-${teamId}:${userId}`;
+
+export const initializeStorage = (redisURL) => {
+  const redisClient = redis.createClient(process.env.REDIS_URL);
+  redisClient.on("error", error => console.error(error));
+  redisClient.on("connect", () => console.error("🙆‍♂️Redis connected"));
+  const redisGet = promisify(redisClient.get).bind(redisClient);
+  const redisSet = promisify(redisClient.set).bind(redisClient);
+  
+  return {
+    // saves a Bolt installed team object
+    saveInstalledTeam: async (installation) => {
+      const key = makeInstalledTeamKey(installation.team.id)
+      const value = JSON.stringify(installation)
+      return await redisSet(key, value)
+    },
+
+    // returns the whole Bolt installed team object
+    getInstalledTeam: async (teamId) => {
+      const key = makeInstalledTeamKey(teamId)
+      const val = await redisGet(key)
+      try {
+        return JSON.parse(val)
+      } catch(e) {
+        console.error(`Error parsing ${key} from Redis:`, e.message);
+        return null
+      }
+    },
+
+    // stores a user token for an install by a particular user of a team
+    setUserCredential: async (teamId, userId, token) => {
+      const key = makeUserCredentialKey(teamId, userId);
+      return await redisSet(key, token)
+    },
+
+    // Get a user token for an install by a particular user of a team
+    getUserCredential: async (teamId, userId) => {
+      const key = makeUserCredentialKey(teamId, userId);
+      return await redisGet(key)
+    }
+  }
+}

--- a/update-slack-status-step/constants.js
+++ b/update-slack-status-step/constants.js
@@ -9,4 +9,3 @@ export const BLOCK_STATUS_EMOJI = "status_emoji";
 export const ELEMENT_STATUS_EMOJI = "element_status_emoji";
 
 export const BLOCK_ACCOUNT = "account";
-export const ACTION_DISCONNECT = "disconnect";

--- a/update-slack-status-step/constants.js
+++ b/update-slack-status-step/constants.js
@@ -1,0 +1,12 @@
+export const STEP_CALLBACK_ID = "update_status";
+export const VIEW_CALLBACK_ID = "update_status_view";
+
+// Block & Action IDs
+export const BLOCK_STATUS_TEXT = "status_text";
+export const ELEMENT_STATUS_TEXT = "element_status_text";
+
+export const BLOCK_STATUS_EMOJI = "status_emoji";
+export const ELEMENT_STATUS_EMOJI = "element_status_emoji";
+
+export const BLOCK_ACCOUNT = "account";
+export const ACTION_DISCONNECT = "disconnect";

--- a/update-slack-status-step/index.js
+++ b/update-slack-status-step/index.js
@@ -86,16 +86,15 @@ export const registerUpdateSlackStatusStep = function (app, storage) {
           // In this scenario, the user hasn't authenticated w/ the app yet
           // and the step has no credential configured, so we'll force a connect account view
 
-          // No view state for connect account view
-          const viewState = {};
-
-          view = renderWorkflowStep(
-            null,
+          const view = renderWorkflowStep(
+            {},
             renderConnectAccount({
               oauthURL,
             })
           );
           view.external_id = externalViewId;
+          // Cannot save step until we authenticate
+          view.submit_disabled = true;
 
           await app.client.views.open({
             token: context.botToken,

--- a/update-slack-status-step/index.js
+++ b/update-slack-status-step/index.js
@@ -18,7 +18,7 @@ import {
 } from "./view.js";
 
 export const registerUpdateSlackStatusStep = function (app, storage) {
-  console.log(`⚙️  Registering ${STEP_CALLBACK_ID}`)
+  console.log(`⚙️  Registering ${STEP_CALLBACK_ID}`);
   configureOauth(app, storage);
 
   // Register step config action
@@ -44,14 +44,23 @@ export const registerUpdateSlackStatusStep = function (app, storage) {
       const currentTeamId = team.id;
 
       let userId = get(inputs, "user_id.value");
-      let credentialTeamId = get(inputs, "credential_team_id.value", currentTeamId);
-      let credentialUserId = get(inputs, "credential_user_id.value", currentUserId);
-      
+      let credentialTeamId = get(
+        inputs,
+        "credential_team_id.value",
+        currentTeamId
+      );
+      let credentialUserId = get(
+        inputs,
+        "credential_user_id.value",
+        currentUserId
+      );
+
       const statusText = get(inputs, "status_text.value");
       const statusEmoji = get(inputs, "status_emoji.value");
 
       // configured user if we have it set w/ a credential, otherwise current user
-      const onBehalfOfUserId = userId && credentialUserId ? userId : currentUserId;
+      const onBehalfOfUserId =
+        userId && credentialUserId ? userId : currentUserId;
 
       const userInfo = await app.client.users.info({
         token: context.botToken,
@@ -73,7 +82,10 @@ export const registerUpdateSlackStatusStep = function (app, storage) {
 
       app.logger.info("Retreiving credential", currentTeamId, currentUserId);
       // Check to see if we have a stored credential for the current user already
-      const userToken = await storage.getUserCredential(currentTeamId, currentUserId)
+      const userToken = await storage.getUserCredential(
+        currentTeamId,
+        currentUserId
+      );
       app.logger.info("Credential exists", !!userToken);
 
       // We found a token for the current user, but step isn't configured for anyone yet, let's default to them
@@ -158,7 +170,13 @@ export const registerUpdateSlackStatusStep = function (app, storage) {
   // Handle saving of step config
   app.view(VIEW_CALLBACK_ID, async ({ ack, view, body, context }) => {
     // Pull out any values from our view's state that we need that aren't part of the view submission
-    const { userId, credentialTeamId, credentialUserId } = parseStateFromView(view);
+    const {
+      userId,
+      credentialTeamId,
+      credentialUserId,
+      userName,
+      userImage,
+    } = parseStateFromView(view);
     const workflowStepEditId = get(body, `workflow_step.workflow_step_edit_id`);
 
     const statusText = get(
@@ -223,6 +241,8 @@ export const registerUpdateSlackStatusStep = function (app, storage) {
           label: `Updated status emoji`,
         },
       ],
+      step_name: `Update Slack Status for ${userName}`,
+      step_image_url: userImage,
     };
 
     app.logger.info("Updating step", params);
@@ -243,11 +263,20 @@ export const registerUpdateSlackStatusStep = function (app, storage) {
     }
 
     const { inputs = {}, workflow_step_execute_id } = workflow_step;
-    const { status_text, status_emoji, user_id, credential_team_id, credential_user_id } = inputs;
+    const {
+      status_text,
+      status_emoji,
+      user_id,
+      credential_team_id,
+      credential_user_id,
+    } = inputs;
 
     try {
       // Get the credential for the api call
-      const userToken = await storage.getUserCredential(credential_team_id.value, credential_user_id.value);
+      const userToken = await storage.getUserCredential(
+        credential_team_id.value,
+        credential_user_id.value
+      );
       const statusText = status_text.value || "";
       const statusEmoji = status_emoji.value || "";
 

--- a/update-slack-status-step/index.js
+++ b/update-slack-status-step/index.js
@@ -1,0 +1,281 @@
+import get from "lodash.get";
+import { configureOauth, buildOAuthURL } from "./oauth.js";
+import {
+  STEP_CALLBACK_ID,
+  VIEW_CALLBACK_ID,
+  BLOCK_STATUS_TEXT,
+  ELEMENT_STATUS_TEXT,
+  BLOCK_STATUS_EMOJI,
+  ELEMENT_STATUS_EMOJI,
+  ACTION_DISCONNECT,
+} from "./constants.js";
+import {
+  renderWorkflowStep,
+  renderConnectAccount,
+  renderUpdateStatusForm,
+  parseStateFromView,
+  getConnectAccountViewId,
+} from "./view.js";
+
+export const registerUpdateSlackStatusStep = function (app, storage) {
+  console.log(`⚙️  Registering ${STEP_CALLBACK_ID}`)
+  configureOauth(app, storage);
+
+  // Register step config action
+  app.action(
+    {
+      type: "workflow_step_edit",
+      callback_id: STEP_CALLBACK_ID,
+    },
+    async ({ body, ack, context }) => {
+      ack();
+
+      const {
+        workflow_step: {
+          inputs = {},
+          workflow_id: workflowId,
+          step_id: stepId,
+        } = {},
+        user,
+        team,
+      } = body;
+
+      const currentUserId = user.id;
+      const currentTeamId = team.id;
+
+      let userId = get(inputs, "user_id.value");
+      let credentialTeamId = get(inputs, "credential_team_id.value", currentTeamId);
+      let credentialUserId = get(inputs, "credential_user_id.value", currentUserId);
+      
+      const statusText = get(inputs, "status_text.value");
+      const statusEmoji = get(inputs, "status_emoji.value");
+
+      // configured user if we have it set w/ a credential, otherwise current user
+      const onBehalfOfUserId = userId && credentialUserId ? userId : currentUserId;
+
+      const userInfo = await app.client.users.info({
+        token: context.botToken,
+        user: onBehalfOfUserId,
+      });
+
+      const viewState = {
+        // Set to the current user
+        userId: onBehalfOfUserId,
+        credentialTeamId,
+        credentialUserId,
+        userName: userInfo.user.real_name,
+        userImage: userInfo.user.profile.image_192,
+        statusText,
+        statusEmoji,
+      };
+
+      let view = null;
+
+      app.logger.info("Retreiving credential", currentTeamId, currentUserId);
+      // Check to see if we have a stored credential for the current user already
+      const userToken = await storage.getUserCredential(currentTeamId, currentUserId)
+      app.logger.info("Credential exists", !!userToken);
+
+      // We found a token for the current user, but step isn't configured for anyone yet, let's default to them
+      if (userToken && !userId) {
+        userId = currentUserId;
+      }
+
+      // Need a custom view id so we can update it in our oauth callback
+      const externalViewId = getConnectAccountViewId({
+        workflowId,
+        stepId,
+        userId: currentUserId,
+      });
+
+      // Render connect account view
+      if (!userId || !userToken) {
+        const oauthState = {
+          externalViewId,
+          userId: currentUserId,
+          teamId: currentTeamId,
+        };
+
+        view = renderWorkflowStep(
+          viewState,
+          renderConnectAccount({
+            oauthURL: buildOAuthURL({
+              state: oauthState,
+              team: currentTeamId,
+            }),
+          })
+        );
+      } else if (userId && credentialUserId) {
+        view = renderWorkflowStep(viewState, renderUpdateStatusForm(viewState));
+      }
+
+      // Set an external_id we can use in oauth flow to update it with
+      view.external_id = externalViewId;
+
+      app.logger.info("Opening workflow step view", viewState);
+      await app.client.views.open({
+        token: context.botToken,
+        trigger_id: body.trigger_id,
+        view,
+      });
+    }
+  );
+
+  // Nothing to do here, it's a link button, but need to ack it
+  app.action("connect_account_button", async ({ ack }) => ack());
+
+  app.action(ACTION_DISCONNECT, async ({ ack, body, context }) => {
+    ack();
+
+    const { view, user, team } = body;
+    const currentUserId = user.id;
+    const currentTeamId = team.id;
+    const externalViewId = view.external_id;
+
+    const oauthState = {
+      externalViewId,
+      userId: currentUserId,
+      teamId: currentTeamId,
+    };
+
+    const updatedView = {
+      external_id: externalViewId,
+      ...renderWorkflowStep(
+        {},
+        renderConnectAccount({
+          oauthURL: buildOAuthURL({ state: oauthState, team: currentTeamId }),
+        })
+      ),
+    };
+
+    await app.client.views.update({
+      token: context.botToken,
+      view_id: view.id,
+      view: updatedView,
+    });
+  });
+
+  // Handle saving of step config
+  app.view(VIEW_CALLBACK_ID, async ({ ack, view, body, context }) => {
+    // Pull out any values from our view's state that we need that aren't part of the view submission
+    const { userId, credentialTeamId, credentialUserId } = parseStateFromView(view);
+    const workflowStepEditId = get(body, `workflow_step.workflow_step_edit_id`);
+
+    const statusText = get(
+      view,
+      `state.values.${BLOCK_STATUS_TEXT}.${ELEMENT_STATUS_TEXT}.value`
+    );
+    const statusEmoji = get(
+      view,
+      `state.values.${BLOCK_STATUS_EMOJI}.${ELEMENT_STATUS_EMOJI}.value`
+    );
+
+    const inputs = {
+      user_id: {
+        value: userId,
+      },
+      credential_team_id: {
+        value: credentialTeamId,
+      },
+      credential_user_id: {
+        value: credentialUserId,
+      },
+      status_text: {
+        value: statusText,
+      },
+      status_emoji: {
+        value: statusEmoji,
+      },
+    };
+
+    const errors = {};
+
+    //TODO: validate the statusEmoji is a proper and single emoji string
+
+    if (Object.values(errors).length > 0) {
+      return ack({
+        response_action: "errors",
+        errors,
+      });
+    }
+
+    ack();
+
+    // construct payload for updating the step
+    const params = {
+      token: context.botToken,
+      workflow_step_edit_id: workflowStepEditId,
+      inputs,
+      outputs: [
+        {
+          type: "user",
+          name: "status_user",
+          label: `User who's status was updated`,
+        },
+        {
+          type: "text",
+          name: "status_text",
+          label: `Updated status text`,
+        },
+        {
+          type: "text",
+          name: "status_emoji",
+          label: `Updated status emoji`,
+        },
+      ],
+    };
+
+    app.logger.info("Updating step", params);
+
+    try {
+      // Call the api to save our step config - we do this prior to the ack of the view_submission
+      await app.client.apiCall("workflows.updateStep", params);
+    } catch (e) {
+      app.logger.error("error updating step: ", e.message);
+    }
+  });
+
+  // Handle running the step
+  app.event("workflow_step_execute", async ({ event, context }) => {
+    const { callback_id, workflow_step = {} } = event;
+    if (callback_id !== STEP_CALLBACK_ID) {
+      return;
+    }
+
+    const { inputs = {}, workflow_step_execute_id } = workflow_step;
+    const { status_text, status_emoji, user_id, credential_team_id, credential_user_id } = inputs;
+
+    try {
+      // Get the credential for the api call
+      const userToken = await storage.getUserCredential(credential_team_id.value, credential_user_id.value);
+      const statusText = status_text.value || "";
+      const statusEmoji = status_emoji.value || "";
+
+      await app.client.users.profile.set({
+        token: userToken,
+        profile: {
+          status_text: statusText,
+          status_emoji: statusEmoji,
+        },
+      });
+
+      // Report back that the step completed
+      await app.client.apiCall("workflows.stepCompleted", {
+        token: context.botToken,
+        workflow_step_execute_id,
+        outputs: {
+          status_user: user_id.value,
+          status_text: statusText,
+          status_emoji: statusEmoji,
+        },
+      });
+
+      app.logger.info("step completed", status_text.value, status_emoji.value);
+    } catch (e) {
+      app.logger.error("Error completing step", e.message);
+      await app.client.apiCall("workflows.stepFailed", {
+        token: context.botToken,
+      });
+    }
+  });
+};

--- a/update-slack-status-step/oauth.js
+++ b/update-slack-status-step/oauth.js
@@ -1,0 +1,112 @@
+import { renderWorkflowStep, renderUpdateStatusForm } from "./view.js";
+
+const CLIENT_ID = process.env.SLACK_CLIENT_ID;
+const CLIENT_SECRET = process.env.SLACK_CLIENT_SECRET;
+const HOST = process.env.HOST;
+const OAUTH_PATH = "/update-status-step/auth/callback";
+
+export const configureOauth = (app, storage) => {
+  const expressApp = app.receiver.app;
+
+  expressApp.get(OAUTH_PATH, async (req, res, next) => {
+    let code = req.query.code;
+
+    let state = {};
+    try {
+      state = JSON.parse(req.query.state);
+    } catch (e) {
+      app.logger.error(e);
+      return res
+        .status(500)
+        .send("There was a problem connecting your account");
+    }
+
+    app.logger.info("state: ", state);
+
+    try {
+      const result = await app.client.oauth.v2.access({
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+        code: code,
+        redirect_uri: buildOAuthRedirectURL(),
+      });
+
+      const { id: authedTeamId } = result.team;
+      const { id: authedUserId, access_token: userToken } = result.authed_user;
+      const { userId, teamId, externalViewId } = state;
+
+      // Verify the same team and user was authenticated
+      if (userId !== authedUserId || teamId !== authedTeamId) {
+        res
+          .status(500)
+          .send(
+            "Looks like the wrong team was authenticated, please try again."
+          );
+        return;
+      }
+
+
+      const credentialTeamId = teamId
+      const credentialUserId = userId
+      await storage.setUserCredential(credentialTeamId, credentialUserId, userToken)
+
+      // Get bot token for install
+      const installation = await storage.getInstalledTeam(credentialTeamId)
+      // TODO check if installation not null
+      const botToken = installation.bot.token
+
+      // Get user info
+      const userInfo = await app.client.users.info({
+        token: botToken,
+        user: userId,
+      });
+
+      // Render the new form view w/ the necessary state
+      const viewState = {
+        // Set to the current user
+        userId,
+        // TODO: probably don't need this here
+        credentialTeamId,
+        credentialUserId,
+        userName: userInfo.user.real_name,
+        userImage: userInfo.user.profile.image_192,
+        statusText: "",
+        statusEmoji: "",
+      };
+      const view = renderWorkflowStep(
+        viewState,
+        renderUpdateStatusForm(viewState)
+      );
+
+      // Update the current view via the api w/ new one
+      await app.client.views.update({
+        token: botToken,
+        external_id: externalViewId,
+        view: {
+          ...view,
+        },
+      });
+
+      res
+        .status(200)
+        .send(
+          "Account connected, you can now close this window and return to <a href='slack://'>Slack</a>."
+        );
+    } catch (err) {
+      app.logger.error(err);
+
+      res.status(500).send("There was a problem connecting your account");
+    }
+  });
+};
+
+export const buildOAuthRedirectURL = () => {
+  return `${HOST}${OAUTH_PATH}`;
+};
+
+export const buildOAuthURL = ({ state, team }) => {
+  const redirectURI = buildOAuthRedirectURL();
+  const oauthState = encodeURIComponent(JSON.stringify(state));
+
+  return `https://slack.com/oauth/v2/authorize?user_scope=users.profile:write&client_id=${CLIENT_ID}&redirect_uri=${redirectURI}&state=${oauthState}&team=${team}`;
+};

--- a/update-slack-status-step/view.js
+++ b/update-slack-status-step/view.js
@@ -1,0 +1,168 @@
+import {
+  VIEW_CALLBACK_ID,
+  BLOCK_STATUS_TEXT,
+  ELEMENT_STATUS_TEXT,
+  BLOCK_STATUS_EMOJI,
+  ELEMENT_STATUS_EMOJI,
+  BLOCK_ACCOUNT,
+  ACTION_DISCONNECT,
+} from "./constants.js";
+
+export const renderWorkflowStep = function (state = {}, blocks) {
+  return {
+    type: "workflow_step",
+    // View identifier
+    callback_id: VIEW_CALLBACK_ID,
+    blocks,
+    // Push the state into metadata to have access on view_submission (being kinda lazy and putting more than needed in here)
+    private_metadata: JSON.stringify(state),
+  };
+};
+
+export const renderConnectAccount = ({ oauthURL }) => {
+  const blocks = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `In order to run this step on behalf of you, we'd like to request some permissions from you.`,
+      },
+    },
+    {
+      type: "actions",
+      elements: [
+        {
+          action_id: "connect_account_button",
+          type: "button",
+          style: "primary",
+          text: {
+            type: "plain_text",
+            text: "Request Permissions",
+          },
+          url: oauthURL,
+        },
+      ],
+    },
+  ];
+
+  return blocks;
+};
+
+export const getConnectAccountViewId = ({ userId, workflowId, stepId }) => {
+  return `connect_${workflowId}_${stepId}_${userId}_${Date.now()}`;
+};
+
+// return blocks for the main form
+export const renderUpdateStatusForm = function ({
+  userName,
+  userImage,
+  statusText,
+  statusEmoji,
+}) {
+  const blocks = [
+    {
+      type: "section",
+      block_id: BLOCK_ACCOUNT,
+      text: {
+        type: "mrkdwn",
+        text: `When this step runs, it will update the status of the following user.`,
+      },
+      accessory: {
+        type: "overflow",
+        action_id: ACTION_DISCONNECT,
+        confirm: {
+          title: {
+            type: "plain_text",
+            text: "Disconnect Account",
+          },
+          text: {
+            type: "mrkdwn",
+            text:
+              "Are you sure you want to disconnect this account from this step?  You will need to connect a new account afterwards.",
+          },
+          confirm: {
+            type: "plain_text",
+            text: "Disconnect",
+          },
+          deny: {
+            type: "plain_text",
+            text: "Cancel",
+          },
+          style: "danger",
+        },
+        options: [
+          {
+            text: {
+              type: "plain_text",
+              text: "Disconnect",
+            },
+            value: "disconnect",
+          },
+        ],
+      },
+    },
+    {
+      type: "context",
+      elements: [
+        {
+          type: "image",
+          image_url: userImage,
+          alt_text: userName,
+        },
+        {
+          type: "mrkdwn",
+          text: userName,
+        },
+      ],
+    },
+    {
+      type: "divider",
+    },
+    {
+      type: "input",
+      block_id: BLOCK_STATUS_TEXT,
+      optional: true,
+      element: {
+        action_id: ELEMENT_STATUS_TEXT,
+        type: "plain_text_input",
+        initial_value: statusText || "",
+      },
+      label: {
+        type: "plain_text",
+        text: "Status Text",
+      },
+    },
+    {
+      type: "input",
+      block_id: BLOCK_STATUS_EMOJI,
+      optional: true,
+      element: {
+        action_id: ELEMENT_STATUS_EMOJI,
+        type: "plain_text_input",
+        initial_value: statusEmoji || "",
+      },
+      label: {
+        type: "plain_text",
+        text: "Status Emoji",
+      },
+    },
+  ];
+
+  return blocks;
+};
+
+export const serializeStateForView = (state = {}) => {
+  return JSON.stringify(state);
+};
+
+export const parseStateFromView = (view) => {
+  let state = {};
+
+  try {
+    state = JSON.parse(view.private_metadata);
+  } catch (e) {
+    console.log(e);
+  }
+
+  return state;
+};

--- a/update-slack-status-step/view.js
+++ b/update-slack-status-step/view.js
@@ -86,7 +86,7 @@ export const renderUpdateStatusForm = function ({
     },
   ];
 
-  if (!showChangeAccount && buildOAuthURL) {
+  if (showChangeAccount) {
     blocks.push({
       type: "actions",
       elements: [

--- a/update-slack-status-step/view.js
+++ b/update-slack-status-step/view.js
@@ -5,8 +5,8 @@ import {
   BLOCK_STATUS_EMOJI,
   ELEMENT_STATUS_EMOJI,
   BLOCK_ACCOUNT,
-  ACTION_DISCONNECT,
 } from "./constants.js";
+import { buildOAuthURL } from "./oauth.js";
 
 export const renderWorkflowStep = function (state = {}, blocks) {
   return {
@@ -48,7 +48,7 @@ export const renderConnectAccount = ({ oauthURL }) => {
   return blocks;
 };
 
-export const getConnectAccountViewId = ({ userId, workflowId, stepId }) => {
+export const getConfigureStepViewId = ({ userId, workflowId, stepId }) => {
   return `connect_${workflowId}_${stepId}_${userId}_${Date.now()}`;
 };
 
@@ -56,8 +56,10 @@ export const getConnectAccountViewId = ({ userId, workflowId, stepId }) => {
 export const renderUpdateStatusForm = function ({
   userName,
   userImage,
-  statusText,
-  statusEmoji,
+  statusText = "",
+  statusEmoji = "",
+  showChangeAccount = false,
+  oauthURL = "",
 }) {
   const blocks = [
     {
@@ -66,39 +68,6 @@ export const renderUpdateStatusForm = function ({
       text: {
         type: "mrkdwn",
         text: `When this step runs, it will update the status of the following user.`,
-      },
-      accessory: {
-        type: "overflow",
-        action_id: ACTION_DISCONNECT,
-        confirm: {
-          title: {
-            type: "plain_text",
-            text: "Disconnect Account",
-          },
-          text: {
-            type: "mrkdwn",
-            text:
-              "Are you sure you want to disconnect this account from this step?  You will need to connect a new account afterwards.",
-          },
-          confirm: {
-            type: "plain_text",
-            text: "Disconnect",
-          },
-          deny: {
-            type: "plain_text",
-            text: "Cancel",
-          },
-          style: "danger",
-        },
-        options: [
-          {
-            text: {
-              type: "plain_text",
-              text: "Disconnect",
-            },
-            value: "disconnect",
-          },
-        ],
       },
     },
     {
@@ -115,6 +84,26 @@ export const renderUpdateStatusForm = function ({
         },
       ],
     },
+  ];
+
+  if (!showChangeAccount && buildOAuthURL) {
+    blocks.push({
+      type: "actions",
+      elements: [
+        {
+          action_id: "connect_account_button",
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: "Change to Me",
+          },
+          url: oauthURL,
+        },
+      ],
+    });
+  }
+
+  blocks.push(
     {
       type: "divider",
     },
@@ -145,8 +134,8 @@ export const renderUpdateStatusForm = function ({
         type: "plain_text",
         text: "Status Emoji",
       },
-    },
-  ];
+    }
+  );
 
   return blocks;
 };


### PR DESCRIPTION
The PR add the [update-slack-status](https://github.com/selfcontained/workflow-extensions-examples/tree/master/update-slack-status-step) step copied over from @selfcontained 's original repo. Some modifications were made to the way credential Ids were stored and for the redis configuration but otherwise it is the same. 

Something to think through is if this is a safe way to handle configuration for the credential user and team IDs. As is these can probably be manipulated.