### PR TITLE
Apply VS Code's code formatter

### DIFF
--- a/flow-utilities/index.js
+++ b/flow-utilities/index.js
@@ -2,8 +2,10 @@ import get from "lodash.get";
 import { promisify } from "util";
 import parse from "parse-duration";
 import moment from 'moment';
-import { STEP_CALLBACK_ID, VIEW_CALLBACK_ID, ACTION_SUBTYPE, ELEMENT_DURATION, 
-  BLOCK_DURATION, DELAY_SUBTYPE, REDIS_KEY_SCHEDULE } from "./constants.js";
+import {
+  STEP_CALLBACK_ID, VIEW_CALLBACK_ID, ACTION_SUBTYPE, ELEMENT_DURATION,
+  BLOCK_DURATION, DELAY_SUBTYPE, REDIS_KEY_SCHEDULE
+} from "./constants.js";
 import { renderStepConfig } from "./view.js";
 
 export const registerFlowUtilitiesStep = function (app, storage) {
@@ -49,7 +51,7 @@ export const registerFlowUtilitiesStep = function (app, storage) {
     await client.views.update({
       view_id: view.id,
       view: renderStepConfig(state),
-    });    
+    });
 
   })
 
@@ -58,7 +60,7 @@ export const registerFlowUtilitiesStep = function (app, storage) {
     let metadata = {}
     try {
       metadata = JSON.parse(view.private_metadata)
-    } catch(e) {
+    } catch (e) {
       logger.error("flow-utilities: Error parsing private metadata", e)
     }
 
@@ -109,11 +111,11 @@ export const registerFlowUtilitiesStep = function (app, storage) {
     }
 
     const { inputs = {}, workflow_step_execute_id } = workflow_step;
-    const subtype = ( inputs.subtype || {} ).value || ''
+    const subtype = (inputs.subtype || {}).value || ''
 
     switch (subtype) {
       case DELAY_SUBTYPE:
-        const durationStr = ( inputs.delay_duration || {} ).value || ''
+        const durationStr = (inputs.delay_duration || {}).value || ''
         const durationMs = parse(durationStr) || 0
         const futureUnixTime = moment().add(durationMs, 'ms').unix();
 
@@ -126,10 +128,10 @@ export const registerFlowUtilitiesStep = function (app, storage) {
             step_completed_payload: {
               workflow_step_execute_id
             }
-          }  
+          }
         };
-    
-        storage.addScheduled(REDIS_KEY_SCHEDULE, futureUnixTime, JSON.stringify(scheduled))            
+
+        storage.addScheduled(REDIS_KEY_SCHEDULE, futureUnixTime, JSON.stringify(scheduled))
         break;
       default:
         logger.info(`flow-utilities:workflow_step_execute: unknown subtype=${subtype}`);
@@ -145,7 +147,7 @@ export const registerFlowUtilitiesStep = function (app, storage) {
   // In the future, if we need to guarantee that messages are only processed once, we should implement a distributed
   // lock through Redis.
   let mutex = false;
-  const processInterval =  () => {
+  const processInterval = () => {
     promisify(async () => {
       // Prevent the process intervals from stepping on each other and ensure only one is running at a time.
       // It's OK to skip one, because the iterval will go on firing forever. 
@@ -169,7 +171,7 @@ export const registerFlowUtilitiesStep = function (app, storage) {
               payload.token = botToken;
               await app.client.workflows.stepCompleted(payload);
             }
-          } catch(e) {
+          } catch (e) {
             console.error("flow-utilities: error processing scheduled item", e, item)
           }
 

--- a/flow-utilities/view.js
+++ b/flow-utilities/view.js
@@ -16,49 +16,49 @@ const renderBlocks = function (state) {
   switch (subtype) {
     case DELAY_SUBTYPE:
       return renderDelaySubtype(state)
-      break;  
+      break;
   }
   return renderSubtypeSelection(state)
 };
 
 const renderDelaySubtype = function ({ subtype, delay_duration }) {
   const blocks = [
-		{
-			type: "header",
-			text: {
-				type: "plain_text",
-				text: "Delay progress of the workflow",
-				emoji: true
-			}
-		},
-		{
-			type: "input",
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: "Delay progress of the workflow",
+        emoji: true
+      }
+    },
+    {
+      type: "input",
       block_id: BLOCK_DURATION,
-			element: {
+      element: {
         action_id: ELEMENT_DURATION,
-				type: "plain_text_input",
-				initial_value: delay_duration || "1 minute"
-			},
-			label: {
-				type: "plain_text",
-				text: "Duration",
-				emoji: true
-			}
-		},
-		{
-			type: "context",
-			elements: [
-				{
-					type: "mrkdwn",
-					text: "Provide a duration like `1 hour`, `30s`, `1h 20m`, etc. and we'll do our best to understand it. If the duration cannot be understood, the workflow will continue immediately"
-				}
-			]
-		}
+        type: "plain_text_input",
+        initial_value: delay_duration || "1 minute"
+      },
+      label: {
+        type: "plain_text",
+        text: "Duration",
+        emoji: true
+      }
+    },
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: "Provide a duration like `1 hour`, `30s`, `1h 20m`, etc. and we'll do our best to understand it. If the duration cannot be understood, the workflow will continue immediately"
+        }
+      ]
+    }
   ]
   return blocks
 }
 
-const renderSubtypeSelection = function ({}) {
+const renderSubtypeSelection = function ({ }) {
   const blocks = [
     {
       type: "section",

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const app = new Bolt.App({
     fetchInstallation: async (installQuery) => {
       return storage.getInstalledTeam(installQuery.teamId)
     },
-  },  
+  },
 });
 
 registerRandomStringStep(app);

--- a/storage.js
+++ b/storage.js
@@ -1,7 +1,7 @@
 import { promisify } from "util";
 import redis from "redis";
 
-const makeInstalledTeamKey = (teamId) => 
+const makeInstalledTeamKey = (teamId) =>
   `team-install-${teamId}`;
 const makeUserCredentialKey = (teamId, userId) =>
   `user-credential-${teamId}:${userId}`;


### PR DESCRIPTION
This pull request just applies VS Code's default JS code formatter, mainly for easiness to read `flow-utilities/view.js`.